### PR TITLE
docs(blog): four-backtick fence for nested code examples

### DIFF
--- a/src/content/blog/.CLAUDE.md
+++ b/src/content/blog/.CLAUDE.md
@@ -85,6 +85,7 @@ Based on analysis of all 30+ posts (2022–2026). The authentic voice comes from
 - Use `//bad` and `//good` labels when contrasting approaches
 - Real code from real projects > contrived examples
 - Comparison tables work well for benchmarks (see bun-modules post)
+- **Nested fences:** if a code example itself contains a triple-backtick fence (e.g. showing markdown/MDX, or a reveal.js `data-template` with a ` ```js ` block inside), wrap the OUTER example in a four-backtick fence (`` ```` ``). A three-backtick outer fence is closed early by the inner ``` and silently breaks MDX parsing for the rest of the file.
 
 ## Hero Images
 


### PR DESCRIPTION
Small docs-only follow-up to #86.

The reveal.js post's HTML example contained a nested ` ```js ` fence inside the outer code block, which closed the three-backtick outer fence early and silently broke MDX parsing. Fixed in #86 with a four-backtick outer fence; this documents the rule in the blog style guide so it doesn't recur.

**Why it wasn't in #86:** I pushed this doc commit to the `blog/claude-revealjs-slides` branch a moment after #86 was already merged, so it stranded on the merged branch instead of landing. This PR lands it cleanly on master.

Single-line change to `src/content/blog/.CLAUDE.md`, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)