### PR TITLE
fix: land learn-with-ai rewrite + CLAUDE.md voice-guide pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Personal portfolio and blog site built with Astro 5.
 
+## Writing Blog Posts
+
+Before writing or editing any blog post, read **BOTH**:
+
+1. This file (structure, routing, frontmatter, hero-image workflow).
+2. **[`src/content/blog/.CLAUDE.md`](src/content/blog/.CLAUDE.md)** - the authoritative voice/style guide derived from all 30+ posts. It defines the conversational, self-deprecating voice, the 300-700 word target (900 hard max), banned AI-tell words (leverage, utilize, delve, "game changer", etc.), and the structure/punctuation rules.
+
+Do not write from the top-level conventions alone - the voice guide is where posts actually pass or fail. (A stale `.cursor/rules/blog-creation-rule.mdc` also exists but contradicts the voice guide in places; prefer `blog/.CLAUDE.md`.)
+
 ## Tech Stack
 
 - **Framework**: Astro 5 with MDX

--- a/src/content/blog/learn-with-ai/index.md
+++ b/src/content/blog/learn-with-ai/index.md
@@ -5,72 +5,69 @@ path: /blog/learn-with-ai/
 published: true
 heroImage: ./header.png
 tags: [ai, learning, productivity, workflow]
-description: "Everyone is racing to make AI build for them. The bigger unlock is making it teach you. A tweet reminded me that the people who use AI to learn are the ones who pull away from everyone else."
+description: "Everyone is racing to make AI build for them. The bigger win is making it teach you. A tweet reminded me I have been sleeping on the best thing this stuff does."
 ---
 
-Almost everything I read about AI right now is about output. Ship faster, generate more, close more tickets, one person doing the work of five. I do plenty of that myself. But a tweet stopped me the other day, and it was not about shipping at all:
+Everyone I follow is busy making AI *do* their work. Ship faster, close more tickets, one person doing the job of five. I do it too, most days. Then a tweet last week stopped me, and it had nothing to do with output:
 
 > AI won't replace you. But the people who use AI to learn will replace the people who don't.
 
-I bookmarked it, sat with it, and realized I had been under-using the single most valuable thing this technology does. Not writing my code. Making me the kind of engineer who does not need it to.
+I bookmarked it, went back to it three times, and realized I have been sleeping on the single best thing this stuff does. Not writing my code. Making me good enough that I don't need it to.
 
-## The thing nobody is optimizing for
+## The part nobody optimizes for
 
-The framing came from [a tweet riffing on Andrej Karpathy's long-running point](https://x.com/0xCodila/status/2073150805750714387): the real leverage of AI is not automation, it is tutoring. And the reason that matters is older than any model.
+The line came from [a tweet](https://x.com/0xCodila/status/2073150805750714387) riffing on an old Karpathy point: the real trick with AI isn't automation, it's tutoring. And the reason it hits is way older than any model.
 
-Back in 1984, an education researcher named Benjamin Bloom published what he called the "2 Sigma Problem." Students who got one-on-one tutoring performed two standard deviations better than students in a normal classroom. Two sigma is enormous. The average tutored student ended up beating 98 percent of the students who sat in the regular class. We have known for forty years that personal tutoring is the highest-leverage form of learning that exists. The only problem was that it did not scale. One tutor, one student, does not fit eight billion people.
+Back in 1984 a researcher named Benjamin Bloom ran the numbers on one-on-one tutoring. Kids who got a personal tutor did two standard deviations better than kids in a normal classroom. Two sigma is massive, the average tutored kid beat 98% of the classroom. So we have known for forty years that a personal tutor is the best way to learn anything, and the only catch was it did not scale. One tutor, one student, does not go around for eight billion people.
 
-That constraint is gone. You now have a tutor that has read almost everything, is available at 2am, never gets bored of your questions, and costs less than lunch. Most people are pointing it at their to-do list. The interesting move is pointing it at the gaps in your own head.
+That catch is just gone now. You have a tutor that read most of the internet, never sleeps, never sighs at your dumb question, and costs less than a coffee. Most of us point it at our to-do list. The fun part is pointing it at the holes in your own head.
 
-## The formula that actually works
+## The three moves
 
-The tweet broke it into three steps, and they line up exactly with why real tutoring beats a lecture:
+The tweet broke it into three, and they line up exactly with why a real tutor beats a lecture.
 
-**1. It adapts to what you already know.** A good tutor does not restart from zero. They find the thing you understand and build a bridge from it. AI does this on command, and most people never ask it to. I do backend and frontend work all day, so when I want to understand something unfamiliar I tell it what I already know and make it meet me there:
-
-```
-Explain how database write-ahead logging works, but explain it
-in terms of a React reducer and an action log, because that is
-the mental model I already have. Use my language, not the textbook's.
-```
-
-The concept lands in about a third of the time, because I am not learning a new domain and a new vocabulary at once. I am learning one new idea, wired into scaffolding I already trust.
-
-**2. It challenges you at your exact level.** Not too easy, not too hard. This is the part a book or a course cannot do, because they are written for the average reader and you are not average at anything specific. Ask the model to find your edge:
+**Meet you where you are.** A good tutor doesn't start from zero, they find the thing you already get and build a bridge from it. The model will do this on command and almost nobody asks. I live in frontend and backend all day, so when something new shows up I make it come to me:
 
 ```
-I think I understand event loops. Ask me three questions that
-get progressively harder until I get one wrong, then teach me
-exactly the thing I got wrong. Do not flatter me.
+Explain write-ahead logging, but in terms of a React reducer and
+an action log, because that's the model already in my head.
+Use my words, not the textbook's.
 ```
 
-That "do not flatter me" line matters. Left alone these models will tell you your understanding is excellent. Push them to find where you break, and the break is where the learning happens.
+Lands in a third of the time, because now I'm learning one new idea instead of a new idea plus a new dictionary.
 
-**3. It scales the one thing that used to be scarce.** The whole 2-sigma effect, on demand, for whatever you are stuck on. That is the part that feels almost unfair.
+**Poke where it hurts.** Not too easy, not too hard. A book can't do this, it's written for the average reader and you are not average at anything in particular. So make it find your edge:
 
-## Learn with it, do not launder through it
+```
+I think I get event loops. Ask me three questions, each harder
+than the last, until I miss one. Then teach me the thing I missed.
+Don't flatter me.
+```
 
-Here is the trap, and I fall into it constantly. There is a difference between using AI to *skip* the learning and using AI to *compress* it.
+That last line matters. Left alone these things will tell you your understanding is "excellent." Push it to find where you crack, and the crack is the whole point.
 
-Skipping is when I paste an error, paste the fix, move on, and could not explain a word of what changed. It feels productive. It leaves me exactly as capable as I was that morning, and slightly more dependent than I was the day before. Do that for a year and you have shipped a lot and grown zero.
+**Do it on repeat.** The 2-sigma thing, on tap, for whatever has you stuck. That is the part that feels a little unfair.
 
-Compressing is when I paste the same error and ask *why* it happened, what the underlying model is, and what I would look for next time without the tool. Same amount of time. Completely different result. One buys me a fix. The other buys me a fix and a permanent upgrade to the engineer who hits that class of bug next month.
+## Learning vs laundering
 
-The tell is simple. After the AI helps you, close the window and try to explain what happened out loud. If you cannot, you laundered the work. You did not learn anything.
+Here's the trap, and I fall in it constantly. There's a difference between using AI to *skip* the learning and using it to *shrink* the learning.
 
-## Where I actually use this
+Skipping is pasting the error, pasting the fix, moving on, and not being able to explain one line of what changed. Feels great. Leaves you exactly as capable as you were at breakfast, and a little more dependent than yesterday. Do that for a year and you've shipped a mountain and grown nothing.
 
-Not in the abstract. Concretely, this is where the tutor loop has paid off for me:
+Shrinking is pasting the same error and asking *why*, what the underlying thing is, what you would look for next time without the tool. Same ten minutes. Completely different you at the end of it.
 
-- **Reading unfamiliar code.** I wrote a whole piece on [using AI to understand a complex codebase](/blog/how-to-understand-complex-code-with-ai/). That is this exact muscle, pointed at a repo instead of a topic. Ask it to explain the system through the parts you already recognize.
-- **Neovim internals.** I have spent years in Vim and still hit corners I do not understand. Instead of copying a config snippet, I make it explain *why* the snippet works, which is how I stopped treating my editor like a black box.
-- **New domains at work.** When I get dropped into a service I have never touched, I do not read the docs top to bottom. I have the model quiz me on the parts I claim to understand and teach me the parts I clearly do not.
-- **The concepts under the tools.** It is easy to learn that a command works. It is more valuable to learn why, because the why transfers and the command does not.
+The tell is stupid simple. After the AI helps, close the tab and try to say out loud what just happened. Can't? You laundered it, nothing stuck.
 
-## The compounding part
+## Where this actually pays off
 
-Shipping with AI is a flat trade. You get today's output today. Learning with AI compounds. Every gap you close makes the next thing faster to learn, and the gap between you and the person who only ships gets wider every week, quietly, in a way that does not show up in a single day's work.
+Not in theory. Concretely:
 
-I am not going to stop using AI to build. But I am going to spend a real slice of that time making it teach me instead, because in a year the people who did that will not be competing with the people who did not. They will just be somewhere else entirely.
+- Reading code I have never seen. I wrote a whole thing on [understanding a strange codebase with AI](/blog/how-to-understand-complex-code-with-ai/), and this is that same muscle pointed at a repo.
+- Neovim corners I have faked for years. I make it explain *why* the config line works instead of copying it, which is how I stopped treating my editor like a [blackhole](/blog/vim-is-a-blackhole/).
+- Getting dropped into a service at work. I don't read the docs top to bottom, I have it quiz me on the parts I claim to know.
 
-Bookmark the tweet if you want. Then go ask it to teach you the thing you have been faking for six months.
+Shipping with AI is a flat trade, today's output for today. Learning with it compounds, and the gap between you and the person who only ships gets quietly wider every week.
+
+I'm not going to stop building with it. I'm just going to spend a real chunk of that time making it teach me, because in a year those are not the same person.
+
+Bookmark the tweet if you want. Then go ask it to teach you the thing you've been faking for six months.


### PR DESCRIPTION
Corrective PR. Two changes that were meant to land via #88 but never reached master (they were pushed to the branch *after* #88 had already been merged, so pushing did nothing).

**1. learn-with-ai post rewrite.** The version merged to master is the original 1105-word draft with "leverage" ×2 and a polished-essay tone. This replaces it with the intended 852-word rewrite that follows `src/content/blog/.CLAUDE.md`: conversational/self-deprecating voice, no banned words, no em-dashes.

**2. CLAUDE.md.** Adds the "Writing Blog Posts" section directing authors to read the voice guide (`src/content/blog/.CLAUDE.md`), not just the top-level conventions. Applied on top of current master so it keeps #87's colon/em-dash fixes.

Built off current master (post from `blog/use-ai-to-learn` @ 9c84cf5a; CLAUDE.md re-applied cleanly). The stale `blog/use-ai-to-learn` branch can be deleted after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)