### PR TITLE
SEO polish

### DIFF
--- a/src/content/blog/being-cheap-with-your-tools/index.md
+++ b/src/content/blog/being-cheap-with-your-tools/index.md
@@ -4,13 +4,13 @@ date: 2026-07-05
 heroImage: ./header.png
 path: /blog/being-cheap-with-your-tools/
 published: true
-tags: [productivity, developer-life, tools, mindset]
-description: "I wore never paying for software like a badge of honor. It was actually the most expensive habit I had. A developer's case against being cheap with your own tools."
+tags: [productivity, developer-tools, developer-life, mindset, career]
+description: "I wore never paying for software like a badge of honor. It was actually the most expensive habit I had. A developer's case against the false economy of being cheap with your own tools."
 ---
 
 For years I wore it like a badge. I never paid for software. Free tier of everything, the trial I kept resetting with a new email, the fifteen tabs of the paid feature I refused to unlock for nine dollars a month. I thought I was being clever. I was being broke in the one currency I could not get back, which is time.
 
-I read a piece by [Tim Denning](https://x.com/Tim_Denning/) about how being cheap keeps you broke, and it read like a personal attack. So here is my version, aimed squarely at us developers, because we are some of the worst offenders.
+And nobody falls into this trap harder than developers. We are some of the worst offenders, so here is the case, aimed squarely at us.
 
 ## The price you see is not the cost
 

--- a/src/content/blog/local-ci-with-gh-signoff/index.md
+++ b/src/content/blog/local-ci-with-gh-signoff/index.md
@@ -4,13 +4,13 @@ date: 2026-07-05
 heroImage: ./header.png
 path: /blog/local-ci-with-gh-signoff/
 published: true
-tags: [ci, github, cli, workflow, productivity]
-description: "A GitHub CLI extension from Basecamp that lets you run tests on your own fast laptop and sign off with a green commit status, instead of waiting on slow cloud CI."
+tags: [ci, local-ci, github, cli, testing, workflow, productivity]
+description: "Local CI with gh-signoff, a GitHub CLI extension from Basecamp. Run your tests on your own fast laptop and sign off with a green commit status instead of waiting on slow, rented cloud CI."
 ---
 
 I have spent more of my life than I want to admit staring at a spinning yellow dot on a pull request. Push, wait, go make coffee, come back, it failed on a lint rule, push again, wait again. The whole time my laptop, the same machine that ran those exact tests in eight seconds locally, is sitting there doing absolutely nothing.
 
-Then I bookmarked a tweet from Cory House and it pointed me to `gh-signoff`, a tiny thing from the Basecamp folks. The idea is almost rude in how simple it is.
+Then I found `gh-signoff`, a tiny thing from the Basecamp folks. The idea is almost rude in how simple it is.
 
 ## The whole pitch in one line
 

--- a/src/content/blog/the-part-of-the-job-ai-cant-grade/index.md
+++ b/src/content/blog/the-part-of-the-job-ai-cant-grade/index.md
@@ -1,18 +1,18 @@
 ---
-title: "The Part of the Job AI Can't Grade"
+title: "The Part of the Job AI Can't Grade - A Developer's Edge in the Age of AI"
 date: 2026-07-06
 heroImage: ./header.png
 path: /blog/the-part-of-the-job-ai-cant-grade/
 published: true
-tags: [career, developer-life, ai, mindset]
-description: "School graded us on solving well-defined problems. Then the machines got great at exactly that. Here is what I think actually matters for a developer's career now."
+tags: [career, developer-life, ai, software-engineering, mindset]
+description: "School graded us on solving well-defined problems, then AI got great at exactly that. Here is what actually matters for a developer's career now: finding the right problems, the last mile, and taste."
 ---
 
 I used to quietly believe that being a good engineer meant being the fastest one to solve the ticket. Hand me a well-defined problem and I would race you to the green checkmark. That was my whole identity for a while.
 
 Then the machines got really, really good at solving well-defined problems. I watched Claude close a bug in about the time it took me to finish reading the description. Small existential wobble. If the thing I was proud of is now a commodity, what exactly am I bringing?
 
-Then I read a piece by [Phil Chen](https://x.com/philhchen/) on career advice in the age of AI, and one line reorganized my head. The work that stays valuable is the work that cannot be graded by a loss function.
+Then something clicked, and it reorganized my head. The work that stays valuable is the work that cannot be graded by a loss function.
 
 ## School optimized us for the wrong thing
 
@@ -30,6 +30,6 @@ Here is the uncomfortable part. AI hands you a competent, slightly soulless medi
 
 ## What's actually scarce
 
-Not code. Not compute. Those got cheap. What stayed scarce is your time, the trust of the people you work with, and your reputation. I spent years guarding my code like it was precious and treating relationships as a nice-to-have. I had it exactly backwards.
+Not code. Not compute. Those got cheap. What stayed scarce is your time, the trust of the people you work with, and your reputation. I spent years guarding my code like it was precious and treating relationships as a nice-to-have. I had it exactly backwards. I wrote before about how [being cheap with your tools is a tax on that same time](/blog/being-cheap-with-your-tools/), and this is the bigger version of that idea.
 
 The machines took the part of the job that had an answer key. Honestly, good riddance. What they left behind is the interesting part, the part that was always the actual job.


### PR DESCRIPTION
Two changes across the 3 recent posts (all previously merged):

**1. Write as Sam's own - no source attribution**
Removed the 'I read a piece by X' framing and source links from all three:
- `local-ci-with-gh-signoff` - dropped the 'bookmarked a tweet from Cory House' line (kept the gh-signoff/Basecamp tool name, since the tool is the subject)
- `being-cheap-with-your-tools` - dropped the Tim Denning attribution
- `the-part-of-the-job-ai-cant-grade` - dropped the Phil Chen attribution

**2. SEO polish (internet-researched, no keyword stuffing)**
- Keyword-aware meta descriptions and expanded tags (local-ci, testing, developer-tools, software-engineering, etc.)
- Added a search-intent subtitle to the career post title ('A Developer's Edge in the Age of AI')
- One natural internal cross-link (career post -> cheap-tools post) with trailing slash
- Bodies unchanged in voice; no SEO blocks, still 300-700 words, no em-dashes/semicolons/banned words

Paths (and therefore URLs) are unchanged, so no SEO equity lost.